### PR TITLE
[UnityAds.h] Add import of UADSInAppPurchaseMetaData to umbrella header.

### DIFF
--- a/UnityAds/UnityAds.h
+++ b/UnityAds/UnityAds.h
@@ -2,7 +2,7 @@
 
 #import <UnityAds/UADSMediationMetaData.h>
 #import <UnityAds/UADSPlayerMetaData.h>
-
+#import <UnityAds/UADSInAppPurchaseMetaData.h>
 /**
  *  An enumerate that describes the state of `UnityAds` placements. 
  *  @note All placement states, other than `kUnityAdsPlacementStateReady`, indicate that the placement is not currently ready to show ads.


### PR DESCRIPTION
Fix warning indicated by Xcode:
Assertion: Umbrella header for module 'UnityAds' does not include header
    'UADSInAppPurchaseMetaData.h'